### PR TITLE
Issue #1: update letsencrypt_base_do parameters

### DIFF
--- a/manifests/letsencrypt_base_do.pp
+++ b/manifests/letsencrypt_base_do.pp
@@ -1,8 +1,9 @@
 class puppet_infrastructure::letsencrypt_base_do (
   String $email,
   String $do_creds_file,
+  String $do_api_token,
+  Array[String] $domains,
   Boolean $automate_deployment        = false,
-  Array[String] $domains              = ["solidangle.eu"],
   Integer $renew_cron_hour            = 4,
   Integer $renew_cron_minute          = 0,
   Integer $deploy_cron_hour           = 5,


### PR DESCRIPTION
Add missing $do_api_token parameter, used in a template. Set no default value for $domains parameter.